### PR TITLE
Show room list on apartment page

### DIFF
--- a/assets/mib-frontend.css
+++ b/assets/mib-frontend.css
@@ -1290,3 +1290,12 @@ width: 100% !important; /* Kis százalékos szélesség, hogy négy blokk elfér
     gap: 10px;
     flex-wrap: wrap !important;
 }
+
+.room-list{
+    list-style: none;
+    padding-left: 0;
+}
+
+.room-list li{
+    margin-bottom: 5px;
+}

--- a/inc/Base/MibBaseController.php
+++ b/inc/Base/MibBaseController.php
@@ -199,9 +199,15 @@ class MibBaseController
 		        'szintrajz' => $szintrajz, // Frissített szintrajz
 		        'notes' => ($item->residentialPark->notes) ? $item->residentialPark->notes : '',
 		        'logo' => ($item->residentialPark->logo) ? $item->residentialPark->logo : '',
-		        'address' => ($item->residentialPark->address) ? $item->residentialPark->address : '',
-		    );
-		}
+                        'address' => ($item->residentialPark->address) ? $item->residentialPark->address : '',
+                        'rooms' => isset($item->rooms) && is_array($item->rooms) ? array_map(function($room){
+                            return [
+                                'category_name' => $room->category_name ?? '',
+                                'floorArea' => $room->floorArea ?? ''
+                            ];
+                        }, $item->rooms) : [],
+                    );
+                }
 
         return $table_data;
 	}
@@ -345,9 +351,18 @@ class MibBaseController
 
 	        $html .= '<div class="info-column">';
 	        $html .= '<h4>Egyéb információk</h4>';
-	        $html .= '<div class="notes">' . $data['notes'] . '</div>';
-	        $html .= '</div>';
-	        $html .= '</div>'; // .apartment-downloads
+                $html .= '<div class="notes">' . $data['notes'] . '</div>';
+
+                if (!empty($data['rooms'])) {
+                    $html .= '<h4>Helyiségek</h4>';
+                    $html .= '<ul class="room-list">';
+                    foreach ($data['rooms'] as $room) {
+                        $html .= '<li>' . esc_html($room['category_name']) . ': ' . esc_html($room['floorArea']) . ' m²</li>';
+                    }
+                    $html .= '</ul>';
+                }
+                $html .= '</div>';
+                $html .= '</div>'; // .apartment-downloads
 
 	        // Ajánlott
 	        $html .= $this->getRecommendedApartmentsHtml($recommend);


### PR DESCRIPTION
## Summary
- parse `rooms` data from API results
- render list of rooms with area on apartment detail page
- style new room list

## Testing
- `composer validate --no-check-all --strict` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c2b5cc69c8325a17f8fe746eba9b6