### PR TITLE
Implement apartment type filter in shortcodes

### DIFF
--- a/assets/mib.js
+++ b/assets/mib.js
@@ -99,15 +99,16 @@ jQuery(document).ready(function($) {
 	});
 
 	// Resetnél:
-	$('#shortcode-form').on('reset', function () {
-	    setTimeout(function () {
-	        residentialParkIds = [];
-	        renderParkTags();
+        $('#shortcode-form').on('reset', function () {
+            setTimeout(function () {
+                residentialParkIds = [];
+                renderParkTags();
 
-	        apartmentSkus = [];
-			renderSkuTags();
-	    }, 0);
-	});
+                apartmentSkus = [];
+                        renderSkuTags();
+                $('#shortcode_type').val('');
+            }, 0);
+        });
 
     // Shortcode szerkesztés
 	$(document).on('click', '.edit-shortcode', function(e) {
@@ -128,11 +129,13 @@ jQuery(document).ready(function($) {
 	                $('#shortcode_name').val(shortcode).prop('readonly', true);
 
 	                // TÖBBES Residential Park ID-k betöltése tagként
-	                residentialParkIds = (data.residential_park_ids || []).map(Number);
-        			renderParkTags();
+                        residentialParkIds = (data.residential_park_ids || []).map(Number);
+                                renderParkTags();
 
-        			apartmentSkus = Array.isArray(data.apartment_skus) ? data.apartment_skus : [];
-					renderSkuTags();
+                                apartmentSkus = Array.isArray(data.apartment_skus) ? data.apartment_skus : [];
+                                        renderSkuTags();
+
+                        $('#shortcode_type').val(data.type || '');
 
 	                $('#residential_park_input').val('');
 	                $('input[name="filters[]"]').prop('checked', false);

--- a/inc/Api/Callbacks/MibManagerCallbacks.php
+++ b/inc/Api/Callbacks/MibManagerCallbacks.php
@@ -339,9 +339,11 @@ class MibManagerCallbacks extends MibBaseController
 		    : [];
 	        $filters = isset($_POST['filters']) ? array_map('sanitize_text_field', $_POST['filters']) : [];
 
-	        $favorites_filter = isset($_POST['favorites_filter']) ? array_map('sanitize_text_field', $_POST['favorites_filter']) : [];
+                $favorites_filter = isset($_POST['favorites_filter']) ? array_map('sanitize_text_field', $_POST['favorites_filter']) : [];
 
-	        $number_of_apartment = isset($_POST['number_of_apartment']) ? $_POST['number_of_apartment'] : [];
+                $number_of_apartment = isset($_POST['number_of_apartment']) ? $_POST['number_of_apartment'] : [];
+
+                $type = isset($_POST['type']) ? sanitize_text_field($_POST['type']) : '';
 
 	        // Intervallum értékek begyűjtése
 	        $ranges = [];
@@ -357,15 +359,16 @@ class MibManagerCallbacks extends MibBaseController
 	        $extras = isset($_POST['extras']) ? array_map('sanitize_text_field', $_POST['extras']) : [];
 
 	        if ($shortcode_name) {
-	            $shortcodes[$shortcode_name] = [
-	                'residential_park_ids' => $residential_park_ids,
-	                'apartment_skus' => $apartment_skus,
-	                'number_of_apartment' => $number_of_apartment,
-	                'filters' => $filters,
-	                'ranges' => $ranges,
-	                'extras' => $extras,
-	                'created_at' => current_time('mysql'),
-	            ];
+                    $shortcodes[$shortcode_name] = [
+                        'residential_park_ids' => $residential_park_ids,
+                        'apartment_skus' => $apartment_skus,
+                        'number_of_apartment' => $number_of_apartment,
+                        'type' => $type,
+                        'filters' => $filters,
+                        'ranges' => $ranges,
+                        'extras' => $extras,
+                        'created_at' => current_time('mysql'),
+                    ];
 	            update_option('mib_custom_shortcodes', serialize($shortcodes));
 	            echo '<div class="notice notice-success is-dismissible"><p>Shortcode mentve: <code>[' . esc_html($shortcode_name) . ']</code></p></div>';
 	        }
@@ -394,10 +397,19 @@ class MibManagerCallbacks extends MibBaseController
 			    <input type="text" id="apartment_sku_input" placeholder="pl. ABC123" style="width: 160px;" />
 			    <button type="button" id="add_apartment_sku" class="button">Hozzáadás</button>
 			</p>
-			<div id="apartment_skus_tags"></div>
-			<input type="hidden" name="apartment_skus" id="apartment_skus_hidden" />
-	        <p>
-	            <label for="filters">Választható szűrők:</label><br>
+                        <div id="apartment_skus_tags"></div>
+                        <input type="hidden" name="apartment_skus" id="apartment_skus_hidden" />
+                        <p>
+                            <label for="shortcode_type">Típus:</label><br>
+                            <select name="type" id="shortcode_type">
+                                <option value="">-- Minden --</option>
+                                <?php foreach ($this->getTypes() as $type) { ?>
+                                    <option value="<?= esc_attr($type); ?>"><?= esc_html($type); ?></option>
+                                <?php } ?>
+                            </select>
+                        </p>
+                <p>
+                    <label for="filters">Választható szűrők:</label><br>
 	            <?php
 	            $available_filters = [
 	                'floor' => 'Emelet',
@@ -449,8 +461,9 @@ class MibManagerCallbacks extends MibBaseController
 	        echo '<thead><tr>';
 	        echo '<th>Shortcode</th>';
 	        echo '<th>Residential Park ID</th>';
-	        echo '<th>Lakás cikkszámok</th>';
-	        echo '<th>Szűrők</th>';
+                echo '<th>Lakás cikkszámok</th>';
+                echo '<th>Típus</th>';
+                echo '<th>Szűrők</th>';
 	        echo '<th>Extra opciók</th>';
 	        echo '<th>Lakások száma egy oldalon</th>';
 	        echo '<th>Műveletek</th>';
@@ -460,8 +473,9 @@ class MibManagerCallbacks extends MibBaseController
 	            echo '<tr>';
 	            echo '<td><code>[' . esc_html($name) . ']</code></td>';
 	            echo '<td>' . (!empty($config['residential_park_ids']) ? implode(', ', array_map('esc_html', $config['residential_park_ids'])) : '-') . '</td>';
-	            echo '<td>' . (!empty($config['apartment_skus']) ? implode(', ', array_map('esc_html', $config['apartment_skus'])) : '-') . '</td>';
-	            echo '<td>' . (!empty($config['filters']) ? implode(', ', array_map('esc_html', $config['filters'])) : '-') . '</td>';
+                    echo '<td>' . (!empty($config['apartment_skus']) ? implode(', ', array_map('esc_html', $config['apartment_skus'])) : '-') . '</td>';
+                    echo '<td>' . (!empty($config['type']) ? esc_html($config['type']) : '-') . '</td>';
+                    echo '<td>' . (!empty($config['filters']) ? implode(', ', array_map('esc_html', $config['filters'])) : '-') . '</td>';
 	            echo '<td>' . (!empty($config['extras']) ? implode(', ', array_map('esc_html', $config['extras'])) : '-') . '</td>';
 	            echo '<td>' . (!empty($config['number_of_apartment']) ? $config['number_of_apartment'] : '-') . '</td>';
 	            echo '<td>';

--- a/inc/Base/MibBaseController.php
+++ b/inc/Base/MibBaseController.php
@@ -58,7 +58,7 @@ class MibBaseController
 	];
 
 
-	private $types = [
+        private $types = [
         'lakás',
         'üzlethelyiség',
         'iroda',
@@ -73,6 +73,10 @@ class MibBaseController
         //  'csökkentett',
     ];
 
+        public function getTypes() {
+            return $this->types;
+        }
+
 	public $numberOfApartmens = 9;
 
 	public $filterOptionDatas = [];
@@ -83,13 +87,15 @@ class MibBaseController
 
 	public $residentialParkId = 12;
 
-	public $shortcodesOptions = [];
+        public $shortcodesOptions = [];
 
-	public $selectedShortcodeOption = [];
+        public $selectedShortcodeOption = [];
 
-	public $selectedApartmanNames = [];
+        public $selectedApartmanNames = [];
 
-	public $shortCodeApartmanName = '';
+        public $shortCodeApartmanName = '';
+
+        public $shortcodeType = '';
 
     public function __construct() {
 

--- a/inc/Base/MibCreateShortCode.php
+++ b/inc/Base/MibCreateShortCode.php
@@ -49,6 +49,8 @@ class MibCreateShortCode extends MibBaseController
 
                 $this->selectedShortcodeOption = $config;
 
+                $this->shortcodeType = isset($config['type']) ? $config['type'] : '';
+
                 list($datas, $total) = $this->getDatas(false, 0, $config['number_of_apartment']);
 
                 $html = $this->getCardHtmlShortCode($datas, $total, 1, $config, $shortcode_name, $this->numberOfApartmens);
@@ -200,6 +202,10 @@ class MibCreateShortCode extends MibBaseController
 
                 if (!empty($this->selectedApartmanNames)) {
                     $arg['name'] = $this->selectedApartmanNames;
+                }
+
+                if (!empty($this->shortcodeType)) {
+                    $arg['type'] = $this->shortcodeType;
                 }
                 $arg['residentialParkId'] = $this->residentialParkId;
                 $all_data = $mibAuth->getApartmentsForFrontEnd($perpage, 1, $arg);

--- a/inc/Base/MibEnqueue.php
+++ b/inc/Base/MibEnqueue.php
@@ -859,14 +859,18 @@ class MibEnqueue extends MibBaseController
 		//Shortcode
 		
 
-		if (!empty($this->filterType['apartment_skus'])) {
-			
-			$args = array_merge($args, ['name' => implode(',', $this->filterType['apartment_skus']) ]);
-		}
+                if (!empty($this->filterType['apartment_skus'])) {
 
-		if (!empty($this->filterType['extras']) && in_array('hide_unavailable', $this->filterType['extras']) ) {
-			$args = array_merge($args, ['status' => 'Available']);
-		}
+                        $args = array_merge($args, ['name' => implode(',', $this->filterType['apartment_skus']) ]);
+                }
+
+                if (!empty($this->filterType['type'])) {
+                        $args = array_merge($args, ['type' => $this->filterType['type']]);
+                }
+
+                if (!empty($this->filterType['extras']) && in_array('hide_unavailable', $this->filterType['extras']) ) {
+                        $args = array_merge($args, ['status' => 'Available']);
+                }
 
 		$page = 1;
 		if (isset($params['page']) ) {
@@ -934,14 +938,18 @@ class MibEnqueue extends MibBaseController
 			$args = array_merge($args, ['residentialParkId' => $this->residentialParkId ]);
 		}
 
-		if (!empty($this->filterType['apartment_skus'])) {
-			
-			$args = array_merge($args, ['name' => implode(',', $this->filterType['apartment_skus']) ]);
-		}
-		if (!empty($this->filterType['extras']) && in_array('hide_unavailable', $this->filterType['extras']) ) {
-			$args = array_merge($args, ['status' => 'Available']);
+                if (!empty($this->filterType['apartment_skus'])) {
 
-		}elseif(!empty($this->filterOptionDatas) && $this->filterOptionDatas['inactive_hide'] == 1){
+                        $args = array_merge($args, ['name' => implode(',', $this->filterType['apartment_skus']) ]);
+                }
+
+                if (!empty($this->filterType['type'])) {
+                        $args = array_merge($args, ['type' => $this->filterType['type']]);
+                }
+                if (!empty($this->filterType['extras']) && in_array('hide_unavailable', $this->filterType['extras']) ) {
+                        $args = array_merge($args, ['status' => 'Available']);
+
+                }elseif(!empty($this->filterOptionDatas) && $this->filterOptionDatas['inactive_hide'] == 1){
 			$args = array_merge($args, ['status' => 'Available']);
 		}
 


### PR DESCRIPTION
## Summary
- expose available property types in `MibBaseController`
- allow selecting type when creating dynamic shortcodes
- display saved type in admin list
- support type filtering in shortcode output and AJAX handlers
- keep shortcode form JS in sync

## Testing
- `composer validate --no-check-all --strict` *(fails: command not found)*
- `php -l inc/Base/MibBaseController.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a69b46f808325957ca7f98cc83594