### PR TITLE
Fix sort selection persistence with shortcodes

### DIFF
--- a/inc/Base/MibEnqueue.php
+++ b/inc/Base/MibEnqueue.php
@@ -971,11 +971,22 @@ class MibEnqueue extends MibBaseController
 
 		$table_data = $this->setDataToTable($datas);
 
-		//egyedi shortcode-os megjelenítés.
-		if (isset($_POST['shortcode']) && !empty($_POST['shortcode'])) {
+                //egyedi shortcode-os megjelenítés.
+                if (isset($_POST['shortcode']) && !empty($_POST['shortcode'])) {
 
-			$html = $this->getCardHtmlShortCode($table_data, $datas['total'], $currentPage, $this->filterType, $_POST['shortcode'], $_POST['apartman_number']);
-		}
+                        // merge dynamic filter configuration with current args so
+                        // sort options remain selected after AJAX refresh
+                        $shortcodeConfig = array_merge($this->filterType, $args);
+
+                        $html = $this->getCardHtmlShortCode(
+                            $table_data,
+                            $datas['total'],
+                            $currentPage,
+                            $shortcodeConfig,
+                            $_POST['shortcode'],
+                            $_POST['apartman_number']
+                        );
+                }
 		elseif ($type == 'card') {
 
 			$html = $this->getCardHtml($table_data, $datas['total'], $currentPage, $args);


### PR DESCRIPTION
## Summary
- ensure sorting preferences persist after AJAX refresh when using shortcode cards

## Testing
- `composer validate --no-check-lock` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685bc16f56608325921bb944de093912