### PR TITLE
Ensure table view filters only apartments

### DIFF
--- a/inc/Base/MibEnqueue.php
+++ b/inc/Base/MibEnqueue.php
@@ -872,6 +872,11 @@ class MibEnqueue extends MibBaseController
                         $args = array_merge($args, ['status' => 'Available']);
                 }
 
+                // Force apartment type for table view
+                if (isset($params['page_type']) && $params['page_type'] === 'table') {
+                        $args = array_merge($args, ['type' => 'lakás']);
+                }
+
 		$page = 1;
 		if (isset($params['page']) ) {
 
@@ -950,8 +955,13 @@ class MibEnqueue extends MibBaseController
                         $args = array_merge($args, ['status' => 'Available']);
 
                 }elseif(!empty($this->filterOptionDatas) && $this->filterOptionDatas['inactive_hide'] == 1){
-			$args = array_merge($args, ['status' => 'Available']);
-		}
+                        $args = array_merge($args, ['status' => 'Available']);
+                }
+
+                // Force apartment type for table view
+                if (isset($params['page_type']) && $params['page_type'] === 'table') {
+                        $args = array_merge($args, ['type' => 'lakás']);
+                }
 
 		$page = 1;
 		if (isset($params['page']) ) {


### PR DESCRIPTION
## Summary
- revert JS type filter usage
- apply apartment type filter in PHP when requesting table views

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cfad11dcc8325873b311ae5e08052