### PR TITLE
Fix search slider reading with noUiSlider

### DIFF
--- a/assets/mib-frontend.js
+++ b/assets/mib-frontend.js
@@ -3457,8 +3457,13 @@ function formatSquareMeter(value) {
 
             sliders.forEach(slider => {
                 const $slider = $('#' + slider.id);
-                if ($slider.length && $slider.data("ui-slider")) {
-                    const values = $slider.slider('option', 'values');
+                if ($slider.length) {
+                    let values;
+                    if ($slider[0].noUiSlider) {
+                        values = $slider[0].noUiSlider.get().map(parseFloat);
+                    } else if ($slider.data('ui-slider')) {
+                        values = $slider.slider('option', 'values');
+                    }
                     if (Array.isArray(values)) {
                         params.set(slider.key + '_min', values[0]);
                         params.set(slider.key + '_max', values[1]);


### PR DESCRIPTION
## Summary
- support noUiSlider when collecting slider values for the search button

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6864e1249c0c8325b5bc34aa9ecc7d9a