### PR TITLE
Enable GitHub based updates

### DIFF
--- a/inc/Base/MibUpdater.php
+++ b/inc/Base/MibUpdater.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Plugin update checker for GitHub releases.
+ */
+namespace Inc\Base;
+
+class MibUpdater extends MibBaseController
+{
+    public function registerFunction()
+    {
+        add_filter('site_transient_update_plugins', array($this, 'check_update'));
+    }
+
+    public function check_update($transient)
+    {
+        if (empty($transient->checked)) {
+            return $transient;
+        }
+
+        $plugin_slug = $this->pluginName;
+        $current_version = defined('MIB_VERSION') ? MIB_VERSION : null;
+
+        if (!$current_version) {
+            return $transient;
+        }
+
+        $response = wp_remote_get('https://api.github.com/repos/lokutus24/mib/releases/latest');
+
+        if (!is_wp_error($response) && isset($response['response']['code']) && $response['response']['code'] == 200) {
+            $data = json_decode(wp_remote_retrieve_body($response));
+            if (isset($data->tag_name) && version_compare($current_version, $data->tag_name, '<')) {
+                $transient->response[$plugin_slug] = (object) array(
+                    'slug'        => dirname($plugin_slug),
+                    'plugin'      => $plugin_slug,
+                    'new_version' => $data->tag_name,
+                    'url'         => $data->html_url,
+                    'package'     => $data->zipball_url,
+                );
+            }
+        }
+
+        return $transient;
+    }
+}

--- a/inc/MibInitial.php
+++ b/inc/MibInitial.php
@@ -17,13 +17,14 @@ final class MibInitial
 	
 	public static function getService(){
 
-		return [
-			Pages\MibDashboard::class,
-			Base\MibEnqueue::class,
-			Base\MibSettingsLink::class,
-			Base\MibCustomEndpoint::class,
-			Base\MibCreateShortCode::class,
-		];
+                return [
+                        Pages\MibDashboard::class,
+                        Base\MibEnqueue::class,
+                        Base\MibSettingsLink::class,
+                        Base\MibCustomEndpoint::class,
+                        Base\MibCreateShortCode::class,
+                        Base\MibUpdater::class,
+                ];
 		
 	}
 

--- a/mib.php
+++ b/mib.php
@@ -10,6 +10,10 @@
 
 defined('ABSPATH') or die('nem kéne..');
 
+if (!defined('MIB_VERSION')) {
+    define('MIB_VERSION', '2.5');
+}
+
 
 
 if (file_exists(dirname(__FILE__)."/vendor/autoload.php")) {


### PR DESCRIPTION
## Summary
- define plugin version constant
- register updater service
- add GitHub update check class

## Testing
- `composer dump-autoload` *(fails: command not found)*
- `php -l mib.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686536f9cf188325a02352523aa74fa4