### PR TITLE
Allow using gallery image in shortcode

### DIFF
--- a/inc/Api/Callbacks/MibManagerCallbacks.php
+++ b/inc/Api/Callbacks/MibManagerCallbacks.php
@@ -433,13 +433,14 @@ class MibManagerCallbacks extends MibBaseController
 	                'load_more' => 'Paginate helyett Load more',
 	                'available_only' => 'Elérhetőség',
 	                'hide_unavailable' => 'Nem elérhetők elrejtése alapbeállítás',
-	                'orientation_filters' => 'Tájolás szűrés',
-	                'display_logo' => 'Logo megjelenítés',
-	                'display_address' => 'Helység megjelenítés',
-	                'garden_connection_filter' => 'Kertkapcsolat szűrés',
-					'staircase_filter' => 'Lépcsőház szűrés',
-					'sort_filter' => 'Rendezés',
-	            ];
+                        'orientation_filters' => 'Tájolás szűrés',
+                        'display_logo' => 'Logo megjelenítés',
+                        'display_address' => 'Helység megjelenítés',
+                        'garden_connection_filter' => 'Kertkapcsolat szűrés',
+                                        'staircase_filter' => 'Lépcsőház szűrés',
+                                        'sort_filter' => 'Rendezés',
+                        'gallery_first_image' => 'Lakás galéria első képének megjelenítése',
+                    ];
 	            echo "<hr><strong>További beállítások:</strong><br>";
 	            foreach ($extra_options as $key => $label) {
 	                echo "<label><input type='checkbox' name='extras[]' value='{$key}'> {$label}</label><br>";

--- a/inc/Base/MibBaseController.php
+++ b/inc/Base/MibBaseController.php
@@ -157,30 +157,43 @@ class MibBaseController
 		    //$alaprajz = (!empty($pdfDocument)) ? '<a href="'.$pdfDocument.'" target="_blank" rel="noopener">Alaprajz megtekintése</a>' : '';
 		    //$szintrajz = (!empty($pngDocument)) ? '<a href="'.$pngDocument.'" target="_blank" rel="noopener">Szintrajz megtekintése</a>' : '';
 		    
-		    $image = '';
-		    $szintrajz = '';
-		    $alaprajz = '';
-			if (isset($item->apartmentsImages) && !empty($item->apartmentsImages)) {
-			    foreach ($item->apartmentsImages as $img) {
-			        if (isset($img->category) && $img->category === 'Gallery' && isset($img->src)) {
-			            $image = $img->src;
-			            //break;
-			        }
-			        if (isset($img->category) && $img->category === 'Synopsis' && isset($img->src)) {
-			            $szintrajz = '<a href="'.$img->src.'" target="_blank" rel="noopener">Szintrajz megtekintése</a>';
-			            //break;
-			        }
-			    }
+                    $image = '';
+                    $szintrajz = '';
+                    $alaprajz = '';
 
-			    foreach ($item->apartmentsDocuments as $img) {
+                    $useGalleryImage = (
+                        !empty($this->selectedShortcodeOption['extras']) &&
+                        in_array('gallery_first_image', $this->selectedShortcodeOption['extras'])
+                    );
 
-			    	if (isset($img->category) && $img->category === 'Floorplan' && isset($img->src)) {
-			            $alaprajz = '<a href="'.$img->src.'" target="_blank" rel="noopener">Alaprajz megtekintése</a>';
-			            break;
-			        }
-			    }
-			    
-			}
+                    if (isset($item->apartmentsImages) && !empty($item->apartmentsImages)) {
+                        foreach ($item->apartmentsImages as $img) {
+                            if (
+                                $useGalleryImage &&
+                                empty($image) &&
+                                isset($img->category) &&
+                                $img->category === 'Gallery' &&
+                                isset($img->src)
+                            ) {
+                                $image = $img->src;
+                            }
+                            if (isset($img->category) && $img->category === 'Synopsis' && isset($img->src)) {
+                                $szintrajz = '<a href="'.$img->src.'" target="_blank" rel="noopener">Szintrajz megtekintése</a>';
+                            }
+                        }
+                    }
+
+                    if (isset($item->apartmentsDocuments) && !empty($item->apartmentsDocuments)) {
+                        foreach ($item->apartmentsDocuments as $img) {
+                            if (isset($img->category) && $img->category === 'Floorplan' && isset($img->src)) {
+                                if (!$useGalleryImage || empty($image)) {
+                                    $image = $img->src;
+                                }
+                                $alaprajz = '<a href="'.$img->src.'" target="_blank" rel="noopener">Alaprajz megtekintése</a>';
+                                break;
+                            }
+                        }
+                    }
 
 		    // Végigmegyünk az adatbázisból lekért csatolmányokon és frissítjük a megfelelő értékeket
 		    if (!empty($attachments)) {

--- a/inc/Base/MibEnqueue.php
+++ b/inc/Base/MibEnqueue.php
@@ -17,10 +17,11 @@ class MibEnqueue extends MibBaseController
 	public function __construct()
 	{
 		parent::__construct();
-		if (isset($_POST['shortcode'])) {
-			$this->filterType = $this->get_shortcode_config_by_name($_POST['shortcode']);
-		}
-	}
+                if (isset($_POST['shortcode'])) {
+                        $this->filterType = $this->get_shortcode_config_by_name($_POST['shortcode']);
+                        $this->selectedShortcodeOption = $this->filterType;
+                }
+        }
 
 	public function registerFunction(){
 


### PR DESCRIPTION
## Summary
- add `Lakás galéria első képének megjelenítése` extra option for shortcodes
- allow shortcodes to display gallery images instead of floorplans when option is set
- pass shortcode settings to AJAX handlers

## Testing
- `php -l inc/Base/MibBaseController.php`
- `php -l inc/Api/Callbacks/MibManagerCallbacks.php`
- `php -l inc/Base/MibEnqueue.php`


------
https://chatgpt.com/codex/tasks/task_e_68a87eb7e1d083258fa98903d54fcaa0