### PR TITLE
Add Otthon Start program filter and badge

### DIFF
--- a/assets/mib-frontend.js
+++ b/assets/mib-frontend.js
@@ -3626,8 +3626,9 @@ function formatSquareMeter(value) {
         const selectAvailability = $('.catalog-availability-checkbox:checked').length;
         const selectGardenConnection = $('.catalog-gardenconnection-checkbox:checked').length;
         const selectStairway = $('.catalog-stairway-checkbox:checked').length;
+        const selectOtthonStart = $('.catalog-otthonstart-checkbox:checked').length;
 
-        if (selectOrientation > 0 || selectAvailability > 0 || selectGardenConnection>0 || selectStairway>0) {
+        if (selectOrientation > 0 || selectAvailability > 0 || selectGardenConnection > 0 || selectStairway > 0 || selectOtthonStart > 0) {
             isActive = true;
         }
 
@@ -3947,6 +3948,20 @@ function formatSquareMeter(value) {
             $filters.css('display', 'flex');
             $button.html('<i class="fas fa-times me-1"></i> Szűrők bezárása');
         }
+    });
+
+    // Otthon start filter
+    $(document).on('change', '.catalog-otthonstart-checkbox', function() {
+        const checked = $(this).is(':checked');
+        $('[data-otthon-start]').each(function() {
+            const match = Number($(this).data('otthon-start')) === 1;
+            if (checked && !match) {
+                $(this).hide();
+            } else {
+                $(this).show();
+            }
+        });
+        checkIfAnyFilterIsActive();
     });
 
 });


### PR DESCRIPTION
## Summary
- calculate Otthon Start eligibility for each apartment and expose badge info
- add Otthon Start badge to listing cards and detail pages
- introduce optional Otthon Start filter with frontend logic

## Testing
- `php -l inc/Base/MibBaseController.php`
- `node --check assets/mib-frontend.js`


------
https://chatgpt.com/codex/tasks/task_e_68b8371111788325b5275d668735cfee