### PR TITLE
Fix apartment catalog grid layout

### DIFF
--- a/inc/Base/MibBaseController.php
+++ b/inc/Base/MibBaseController.php
@@ -900,7 +900,6 @@ class MibBaseController
 
             $html .= $this->getCatalogFilterHtml($filterType);
 
-        $html .= '</div>';
         //mib-stairway
 
         // Display total count returned by API


### PR DESCRIPTION
## Summary
- keep apartment cards inside the `custom-card-container` grid to restore multi-column layout

## Testing
- `php -l inc/Base/MibBaseController.php`


------
https://chatgpt.com/codex/tasks/task_e_68be973ec9848325b6c398dde679b367