### PR TITLE
Handle select filters in catalog shortcode

### DIFF
--- a/assets/mib-frontend.js
+++ b/assets/mib-frontend.js
@@ -2307,6 +2307,13 @@ function formatSquareMeter(value) {
             return this.value;
         }).get();
         const selectGardenConnection = $('.catalog-gardenconnection-checkbox').is(':checked') ? 1 : 0;
+        const selectStairway = $('.catalog-stairway-checkbox:checked').map(function() {
+            return this.value;
+        }).get();
+        const districtValue = urlParams.get('district');
+        if (districtValue) {
+            $('.district-select').val(districtValue);
+        }
 
         var wasAdvancedFiltersVisible = $('#advanced-filters').is(':visible');
 
@@ -2332,6 +2339,8 @@ function formatSquareMeter(value) {
                 availability: selectAvailability,
                 typeOfBalcony: selectOritentation,
                 garden_connection: selectGardenConnection,
+                stairway: selectStairway,
+                district: districtValue,
                 page_type: page_type,
             },
             success: function(response) {
@@ -2360,6 +2369,12 @@ function formatSquareMeter(value) {
                     $('.catalog-gardenconnection-checkbox').prop('checked', true);
                 } else {
                     $('.catalog-gardenconnection-checkbox').prop('checked', false);
+                }
+                selectStairway.forEach(function(value) {
+                    $('.catalog-stairway-checkbox[value="' + value + '"]').prop('checked', true);
+                });
+                if (districtValue) {
+                    $('.district-select').val(districtValue);
                 }
 
                 const cleanUrl = window.location.origin + window.location.pathname;

--- a/inc/Base/MibBaseController.php
+++ b/inc/Base/MibBaseController.php
@@ -1182,7 +1182,29 @@ class MibBaseController
 	}
 
     public function getFilters(){
-        return $this->getCatalogFilterHtml([], true);
+        $filters = [];
+
+        $map = [
+            'district'         => 'district',
+            'orientation'      => 'typeOfBalcony',
+            'availability'     => 'status',
+            'garden_connection'=> 'garden_connection',
+            'stairway'         => 'stairway',
+            'otthonStart'      => 'otthon_start',
+        ];
+
+        foreach ($map as $queryKey => $filterKey) {
+            if (isset($_GET[$queryKey])) {
+                $value = $_GET[$queryKey];
+                if (is_array($value)) {
+                    $filters[$filterKey] = array_map('sanitize_text_field', $value);
+                } else {
+                    $filters[$filterKey] = sanitize_text_field($value);
+                }
+            }
+        }
+
+        return $this->getCatalogFilterHtml($filters, true);
     }
 
     private function getSearch()


### PR DESCRIPTION
## Summary
- Persist select-based filters by forwarding their GET params to catalog filter rendering
- Include district and stairway values in initial AJAX filter request and reapply after load

## Testing
- `php -l inc/Base/MibBaseController.php`
- `node --check assets/mib-frontend.js`

------
https://chatgpt.com/codex/tasks/task_e_68be98cc530c83258f0cc2bddcee31f8