### PR TITLE
Add residential documents shortcode

### DIFF
--- a/assets/mib-frontend.js
+++ b/assets/mib-frontend.js
@@ -4058,4 +4058,14 @@ function formatSquareMeter(value) {
         checkIfAnyFilterIsActive();
     });
 
+    $(document).on('click', '.mib-res-doc-btn', function(e) {
+        e.preventDefault();
+        var u = $(this).closest('.mib-residential-documents').find('.mib-res-doc-select').val();
+        if (!u) {
+            alert('Kérjük, válasszon dokumentumot!');
+            return;
+        }
+        window.open(u, '_blank');
+    });
+
 });

--- a/inc/Base/MibAuthController.php
+++ b/inc/Base/MibAuthController.php
@@ -184,10 +184,10 @@ class MibAuthController extends MibBaseController
 	    return ["data" => $all_data, "total" => $total_records];
 	}
 
-	public function getOneApartmentsById($id)
-	{
-	    $all_data = [];
-	    $total_records = 0;
+        public function getOneApartmentsById($id)
+        {
+            $all_data = [];
+            $total_records = 0;
 
 	    if (empty($this->mibOptions['token'])) {
 	        return ["data" => $all_data, "total" => $total_records];
@@ -218,6 +218,31 @@ class MibAuthController extends MibBaseController
 	        error_log('MIB getOneApartmentsById error: ' . $response->get_error_message());
 	    }
 
-	    return ["data" => $all_data, "total" => $total_records];
-	}
+            return ["data" => $all_data, "total" => $total_records];
+        }
+
+        public function getResidentialDocuments($id)
+        {
+            if (empty($this->mibOptions['token'])) {
+                return [];
+            }
+
+            $url = "https://ugyfel.mibportal.hu:3000/residential_parks/get/{$id}";
+            $response = wp_remote_get($url, [
+                'timeout'     => 10,
+                'redirection' => 10,
+                'httpversion' => '1.1',
+                'headers'     => ['Authorization' => "Bearer {$this->mibOptions['token']}"],
+            ]);
+
+            if (is_wp_error($response)) {
+                error_log('MIB getResidentialDocuments error: ' . $response->get_error_message());
+                return [];
+            }
+
+            $body = wp_remote_retrieve_body($response);
+            $json = json_decode($body, true);
+
+            return $json ?: [];
+        }
 }


### PR DESCRIPTION
## Summary
- move residential documents API call into auth controller with token
- load shortcode documents via controller and render dropdown and download button
- handle document download via mib-frontend.js

## Testing
- `php -l inc/Base/MibCreateShortCode.php`
- `php -l inc/Base/MibAuthController.php`
- `node --check assets/mib-frontend.js`
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68bfe6dcb13883259d3e73ac26895c43