### PR TITLE
Fix gallery popup image load by removing crossorigin attribute

### DIFF
--- a/inc/Base/MibCreateShortCode.php
+++ b/inc/Base/MibCreateShortCode.php
@@ -106,7 +106,7 @@ class MibCreateShortCode extends MibBaseController
             $url = esc_url($img['url'] ?? $preview);
             if ($preview) {
                 $name = esc_attr($img['name'] ?? '');
-                $html .= '<a href="' . $url . '"><img src="' . $preview . '" alt="' . $name . '" decoding="async" crossorigin="anonymous"></a>';
+                $html .= '<a href="' . $url . '"><img src="' . $preview . '" alt="' . $name . '" decoding="async"></a>';
             }
         }
         $html .= '</div>';


### PR DESCRIPTION
## Summary
- remove crossorigin attribute from residential gallery images so Magnific Popup can load full-size images

## Testing
- `php -l inc/Base/MibCreateShortCode.php`
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68c02a0d2d948325b29fccf49a01cbfc