### PR TITLE
Fix gallery popup image load by validating URLs

### DIFF
--- a/inc/Base/MibCreateShortCode.php
+++ b/inc/Base/MibCreateShortCode.php
@@ -103,10 +103,11 @@ class MibCreateShortCode extends MibBaseController
         $html = '<div class="mib-residential-gallery">';
         foreach ($images as $img) {
             $preview = esc_url($img['previewUrl'] ?? '');
-            $url = esc_url($img['url'] ?? $preview);
+            $urlRaw = $img['url'] ?? '';
+            $url = filter_var($urlRaw, FILTER_VALIDATE_URL) ? esc_url($urlRaw) : $preview;
             if ($preview) {
                 $name = esc_attr($img['name'] ?? '');
-                $html .= '<a href="' . $url . '"><img src="' . $preview . '" alt="' . $name . '" decoding="async" crossorigin="anonymous"></a>';
+                $html .= '<a href="' . $url . '"><img src="' . $preview . '" alt="' . $name . '" decoding="async"></a>';
             }
         }
         $html .= '</div>';


### PR DESCRIPTION
## Summary
- validate residential gallery image URLs and fall back to preview when invalid so Magnific Popup can load images

## Testing
- `php -l inc/Base/MibCreateShortCode.php`
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68c02a0d2d948325b29fccf49a01cbfc