### PR TITLE
Enable dark logo selection for dynamic shortcodes

### DIFF
--- a/inc/Api/Callbacks/MibManagerCallbacks.php
+++ b/inc/Api/Callbacks/MibManagerCallbacks.php
@@ -448,6 +448,7 @@ class MibManagerCallbacks extends MibBaseController
                         'orientation_filters' => 'Tájolás szűrés',
                         'district_filter' => 'Kerület szűrés',
                         'display_logo' => 'Logo megjelenítés',
+                        'dark_logo' => 'Sötét logó',
                         'display_address' => 'Helység megjelenítés',
                         'garden_connection_filter' => 'Kertkapcsolat szűrés',
                                         'staircase_filter' => 'Lépcsőház szűrés',

--- a/inc/Base/MibBaseController.php
+++ b/inc/Base/MibBaseController.php
@@ -291,7 +291,10 @@ class MibBaseController
 		        'alaprajz' => $alaprajz, // Frissített alaprajz
 		        'szintrajz' => $szintrajz, // Frissített szintrajz
 		        'notes' => ($item->residentialPark->notes) ? $item->residentialPark->notes : '',
-                    'logo' => (isset($this->filterOptionDatas['mib-dark_logo']) && $this->filterOptionDatas['mib-dark_logo'] == 1)
+                    'logo' => (
+                        (isset($this->filterOptionDatas['mib-dark_logo']) && $this->filterOptionDatas['mib-dark_logo'] == 1) ||
+                        (!empty($this->selectedShortcodeOption['extras']) && in_array('dark_logo', $this->selectedShortcodeOption['extras']))
+                    )
                         ? (($item->residentialPark->darklogo) ? $item->residentialPark->darklogo : '')
                         : (($item->residentialPark->lightlogo) ? $item->residentialPark->lightlogo : ''),
                         'address' => ($item->residentialPark->address) ? $item->residentialPark->address : '',


### PR DESCRIPTION
## Summary
- add `Sötét logó` checkbox option when configuring dynamic shortcodes
- respect the `dark_logo` extra by rendering dark logos when selected

## Testing
- `php -l inc/Api/Callbacks/MibManagerCallbacks.php`
- `php -l inc/Base/MibBaseController.php`


------
https://chatgpt.com/codex/tasks/task_e_68c3e1e9540883259d3e65ddd4a8c38e