### PR TITLE
feat: allow configuring visible park ids

### DIFF
--- a/inc/Api/Callbacks/MibManagerCallbacks.php
+++ b/inc/Api/Callbacks/MibManagerCallbacks.php
@@ -80,6 +80,7 @@ class MibManagerCallbacks extends MibBaseController
 					'mib-display_sort'	  => (isset($_POST['mib-display_sort'] ) && $_POST['mib-display_sort'] == 'on') ? true : false,
 					'mib-garden_connection'	  => (isset($_POST['mib-garden_connection'] ) && $_POST['mib-garden_connection'] == 'on') ? true : false,
 					'mib-stairway'	  => (isset($_POST['mib-stairway'] ) && $_POST['mib-stairway'] == 'on') ? true : false,
+                                        'residential_park_ids' => isset($_POST['residential_park_ids']) ? array_filter(array_map('intval', explode(',', $_POST['residential_park_ids']))) : [],
 				]
 			);
 			update_option('mib_filter_options', $datas);
@@ -123,10 +124,14 @@ class MibManagerCallbacks extends MibBaseController
 		$garden_connection = (isset($mib_filter_options['mib-garden_connection'])  && $mib_filter_options['mib-garden_connection'] == 1) ? 'checked' : '';
 
 		$stairway = (isset($mib_filter_options['mib-stairway'])  && $mib_filter_options['mib-stairway'] == 1) ? 'checked' : '';
+                $residential_park_ids = isset($mib_filter_options['residential_park_ids']) ? implode(',', $mib_filter_options['residential_park_ids']) : '';
 
 		?>
 
 
+                <div class='row' style='margin-bottom: 10px;'>
+                        Lakópark ID-k: <input type='text' name='residential_park_ids' size='45' value='<?=$residential_park_ids;?>' placeholder='pl. 7,9,10'>
+                </div>
 		<div class="row" style="margin-bottom: 10px;">
 			Emeletek: <input type="checkbox" name="mib-filter-floor" size="45" <?=$floor_checked;?> >
 		</div>

--- a/inc/Base/MibBaseController.php
+++ b/inc/Base/MibBaseController.php
@@ -1437,8 +1437,9 @@ class MibBaseController
         $html = '<select class="form-select select-residential-park" id="select-residential-park" aria-label="Lakópark kiválasztása">';
         $html .= '<option value="" selected>Lakópark kiválasztása</option>';
 
-        foreach ($this->parkNames as $id => $parkName) {
-            $name = $parkName;
+        $parkIds = !empty($this->filterOptionDatas['residential_park_ids']) ? $this->filterOptionDatas['residential_park_ids'] : array_keys($this->parkNames);
+        foreach ($parkIds as $id) {
+            $name = $this->parkNames[$id] ?? $id;
             $html .= '<option value="'.$id.'">'.$name.'</option>';
         }
 

--- a/inc/Base/MibEnqueue.php
+++ b/inc/Base/MibEnqueue.php
@@ -854,21 +854,23 @@ class MibEnqueue extends MibBaseController
 		    $args = array_merge($args, ['sortType' => $sortType]);
 		}
 
-		if ( isset($params['residental_park_id']) && !empty($params['residental_park_id']) ) {
-	
-		    $args = array_merge($args, ['residentialParkId' => $params['residental_park_id'] ]);
-		}else{
+            if ( isset($params['residental_park_id']) && !empty($params['residental_park_id']) ) {
 
+                $args = array_merge($args, ['residentialParkId' => $params['residental_park_id'] ]);
+            }else{
 
-			if (!empty($this->filterType['residential_park_ids'])) {
+                    if (!empty($this->filterType['residential_park_ids'])) {
 
-				$args = array_merge($args, ['residentialParkId' => implode(',', $this->filterType['residential_park_ids']) ]);
-			}else{
-				$args = array_merge($args, ['residentialParkId' => $this->residentialParkId ]);
-			}
-		}
+                            $args = array_merge($args, ['residentialParkId' => implode(',', $this->filterType['residential_park_ids']) ]);
+                    }elseif (!empty($this->filterOptionDatas['residential_park_ids'])) {
+                            $args = array_merge($args, ['residentialParkId' => implode(',', $this->filterOptionDatas['residential_park_ids']) ]);
+                    }else{
+                            $args = array_merge($args, ['residentialParkId' => $this->residentialParkId ]);
+                    }
+            }
 
-		//Shortcode
+            //Shortcode
+
 		
 
                 if (!empty($this->filterType['apartment_skus'])) {
@@ -951,14 +953,17 @@ class MibEnqueue extends MibBaseController
        		    $args = array_merge($args, ['sortType' => $sortType]);
        		}
 
-		if (!empty($this->filterType['residential_park_ids'])) {
+            if (!empty($this->filterType['residential_park_ids'])) {
 
-			$args = array_merge($args, ['residentialParkId' => implode(',', $this->filterType['residential_park_ids']) ]);
-		}else{
-			$args = array_merge($args, ['residentialParkId' => $this->residentialParkId ]);
-		}
+                    $args = array_merge($args, ['residentialParkId' => implode(',', $this->filterType['residential_park_ids']) ]);
+            }elseif (!empty($this->filterOptionDatas['residential_park_ids'])) {
+                    $args = array_merge($args, ['residentialParkId' => implode(',', $this->filterOptionDatas['residential_park_ids']) ]);
+            }else{
+                    $args = array_merge($args, ['residentialParkId' => $this->residentialParkId ]);
+            }
 
                 if (!empty($this->filterType['apartment_skus'])) {
+
 
                         $args = array_merge($args, ['name' => implode(',', $this->filterType['apartment_skus']) ]);
                 }


### PR DESCRIPTION
## Summary
- add admin setting to specify which park IDs appear in filters
- respect configured park IDs when building front-end park selector and API queries

## Testing
- `php -l inc/Api/Callbacks/MibManagerCallbacks.php`
- `php -l inc/Base/MibBaseController.php`
- `php -l inc/Base/MibEnqueue.php`


------
https://chatgpt.com/codex/tasks/task_e_68c3e78868608325b1d1b0163019e722