### PR TITLE
Limit residential gallery to four images

### DIFF
--- a/assets/mib-frontend.css
+++ b/assets/mib-frontend.css
@@ -1390,7 +1390,7 @@ width: 100% !important; /* Kis százalékos szélesség, hogy négy blokk elfér
 
 .mib-residential-gallery {
     display: grid;
-    grid-template-columns: repeat(2, 1fr); /* Alapból 2 oszlop */
+    grid-template-columns: repeat(4, 1fr); /* Alapból 4 oszlop */
     gap: 30px;
     justify-content: center;
 }

--- a/inc/Base/MibCreateShortCode.php
+++ b/inc/Base/MibCreateShortCode.php
@@ -100,6 +100,9 @@ class MibCreateShortCode extends MibBaseController
             return '<p>Nincsenek képek.</p>';
         }
 
+        // Limit the gallery to the first 4 images even if more are available
+        $images = array_slice($images, 0, 4);
+
         $html = '<div class="mib-residential-gallery">';
         foreach ($images as $img) {
             $preview = esc_url($img['previewUrl'] ?? '');


### PR DESCRIPTION
## Summary
- show only the first four images in the residential gallery shortcode
- present gallery images in a four-column grid layout

## Testing
- `php -l inc/Base/MibCreateShortCode.php`
- `composer validate --no-interaction`


------
https://chatgpt.com/codex/tasks/task_e_68c40cea309c8325aef333ccdc200d03