### PR TITLE
Add property carousel shortcode using Swiper

### DIFF
--- a/assets/mib-carousel.js
+++ b/assets/mib-carousel.js
@@ -1,0 +1,23 @@
+// Initialize Swiper carousel for property shortcode
+document.addEventListener('DOMContentLoaded', function () {
+    var carousels = document.querySelectorAll('.mib-property-carousel');
+    carousels.forEach(function (carousel) {
+        new Swiper(carousel, {
+            slidesPerView: 1,
+            spaceBetween: 20,
+            navigation: {
+                nextEl: carousel.querySelector('.swiper-button-next'),
+                prevEl: carousel.querySelector('.swiper-button-prev')
+            },
+            pagination: {
+                el: carousel.querySelector('.swiper-pagination'),
+                clickable: true
+            },
+            breakpoints: {
+                768: {
+                    slidesPerView: 4
+                }
+            }
+        });
+    });
+});

--- a/inc/Base/MibBaseController.php
+++ b/inc/Base/MibBaseController.php
@@ -1074,9 +1074,9 @@ class MibBaseController
 	    return $html;
 	}
 
-	public function getMoreCards($datas, $totalItems, $currentPage)
-	{
-	    $html = '';
+    public function getMoreCards($datas, $totalItems, $currentPage)
+    {
+        $html = '';
 
 	   
 	    if (!empty($datas)) {
@@ -1190,8 +1190,41 @@ class MibBaseController
 
 	    $html .= '</div>';
 
-	    return $html;
-	}
+        return $html;
+    }
+
+    public function getCarouselHtml($datas)
+    {
+        $html = '<div class="mib-property-carousel swiper">';
+        $html .= '<div class="swiper-wrapper">';
+
+        if (!empty($datas)) {
+            foreach ($datas as $data) {
+                $html .= '<div class="swiper-slide">';
+                $html .= '<div class="card h-100">';
+                $html .= '<div class="primary-color card-image-wrapper">';
+                $html .= '<img src="' . $data['image'] . '" class="card-img-top" alt="Lakás képe" crossorigin="anonymous">';
+                $html .= '</div>';
+                $html .= '<div class="card-body d-flex flex-column">';
+                $html .= '<h5 class="card-title">' . esc_html($data['rawname']) . '</h5>';
+                $html .= '<p class="card-text mb-4">' . esc_html($data['price']) . '</p>';
+                $html .= '<a href="' . $data['url'] . '" class="mt-auto btn btn-primary">' . __('Megnézem', 'mib') . '</a>';
+                $html .= '</div>';
+                $html .= '</div>';
+                $html .= '</div>';
+            }
+        } else {
+            $html .= '<div class="swiper-slide"><p>' . __('Nem található ingatlan', 'mib') . '</p></div>';
+        }
+
+        $html .= '</div>';
+        $html .= '<div class="swiper-button-prev"></div>';
+        $html .= '<div class="swiper-button-next"></div>';
+        $html .= '<div class="swiper-pagination"></div>';
+        $html .= '</div>';
+
+        return $html;
+    }
 
     public function getFilters(){
         $filters = [];

--- a/inc/Base/MibCreateShortCode.php
+++ b/inc/Base/MibCreateShortCode.php
@@ -17,6 +17,7 @@ class MibCreateShortCode extends MibBaseController
         add_shortcode('mib_list_apartman_catalog_filters', array($this, 'mib_list_apartman_catalog_filters'));
         add_shortcode('mib_residential_documents', array($this, 'mib_residential_documents'));
         add_shortcode('mib_residential_gallery', array($this, 'mib_residential_gallery'));
+        add_shortcode('mib_property_carousel', array($this, 'mib_property_carousel'));
 
 
         add_action('init', array($this, 'custom_property_rewrite_rule'));
@@ -241,6 +242,13 @@ class MibCreateShortCode extends MibBaseController
     {
         list($datas, $total) = $this->getDatas(false, 0, 9);
         $html = $this->getCardHtml($datas, $total, 1, []);
+        return $html;
+    }
+
+    public function mib_property_carousel($atts)
+    {
+        list($datas, $total) = $this->getDatas(false, 0, 12);
+        $html = $this->getCarouselHtml($datas);
         return $html;
     }
 

--- a/inc/Base/MibEnqueue.php
+++ b/inc/Base/MibEnqueue.php
@@ -162,6 +162,11 @@ class MibEnqueue extends MibBaseController
         wp_enqueue_script('mib-frontend-script', plugin_dir_url(dirname(__FILE__, 3)).'mib/assets/mib-frontend.js', array('jquery', 'nouislider-js'), null, true);
             wp_localize_script('mib-frontend-script', 'ajaxurl', admin_url('admin-ajax.php'));
 
+        // Swiper carousel for property shortcode
+        wp_enqueue_style('swiper-css', 'https://cdn.jsdelivr.net/npm/swiper@10/swiper-bundle.min.css');
+        wp_enqueue_script('swiper-js', 'https://cdn.jsdelivr.net/npm/swiper@10/swiper-bundle.min.js', array(), null, true);
+        wp_enqueue_script('mib-carousel', plugin_dir_url(dirname(__FILE__, 3)).'mib/assets/mib-carousel.js', array('swiper-js'), null, true);
+
 
             wp_enqueue_style('bootstrap-css', 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css');
                 wp_enqueue_script('bootstrap-js', 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js', array('jquery'), null, true);


### PR DESCRIPTION
## Summary
- add [mib_property_carousel] shortcode to show properties in a responsive Swiper carousel
- render cards in carousel via new getCarouselHtml helper
- enqueue Swiper assets and initialization script

## Testing
- `php -l inc/Base/MibEnqueue.php`
- `php -l inc/Base/MibCreateShortCode.php`
- `php -l inc/Base/MibBaseController.php`
- `node --check assets/mib-carousel.js && echo 'Syntax OK'`


------
https://chatgpt.com/codex/tasks/task_e_68c3fd1275bc8325b5016446a6de0242