### PR TITLE
Add carousel display option for dynamic shortcodes

### DIFF
--- a/inc/Api/Callbacks/MibManagerCallbacks.php
+++ b/inc/Api/Callbacks/MibManagerCallbacks.php
@@ -456,9 +456,10 @@ class MibManagerCallbacks extends MibBaseController
                         'dark_logo' => 'Sötét logó',
                         'display_address' => 'Helység megjelenítés',
                         'garden_connection_filter' => 'Kertkapcsolat szűrés',
-                                        'staircase_filter' => 'Lépcsőház szűrés',
-                                        'sort_filter' => 'Rendezés',
+                        'staircase_filter' => 'Lépcsőház szűrés',
+                        'sort_filter' => 'Rendezés',
                         'gallery_first_image' => 'Lakás galéria első képének megjelenítése',
+                        'carousel_display' => 'Carousel megjelenítés',
                     ];
 	            echo "<hr><strong>További beállítások:</strong><br>";
 	            foreach ($extra_options as $key => $label) {

--- a/inc/Base/MibCreateShortCode.php
+++ b/inc/Base/MibCreateShortCode.php
@@ -17,7 +17,6 @@ class MibCreateShortCode extends MibBaseController
         add_shortcode('mib_list_apartman_catalog_filters', array($this, 'mib_list_apartman_catalog_filters'));
         add_shortcode('mib_residential_documents', array($this, 'mib_residential_documents'));
         add_shortcode('mib_residential_gallery', array($this, 'mib_residential_gallery'));
-        add_shortcode('mib_property_carousel', array($this, 'mib_property_carousel'));
 
 
         add_action('init', array($this, 'custom_property_rewrite_rule'));
@@ -146,7 +145,11 @@ class MibCreateShortCode extends MibBaseController
 
                 list($datas, $total) = $this->getDatas(false, 0, $config['number_of_apartment']);
 
-                $html = $this->getCardHtmlShortCode($datas, $total, 1, $config, $shortcode_name, $this->numberOfApartmens);
+                if (!empty($config['extras']) && in_array('carousel_display', $config['extras'])) {
+                    $html = $this->getCarouselHtml($datas);
+                } else {
+                    $html = $this->getCardHtmlShortCode($datas, $total, 1, $config, $shortcode_name, $this->numberOfApartmens);
+                }
 
                 return $html;
 
@@ -242,13 +245,6 @@ class MibCreateShortCode extends MibBaseController
     {
         list($datas, $total) = $this->getDatas(false, 0, 9);
         $html = $this->getCardHtml($datas, $total, 1, []);
-        return $html;
-    }
-
-    public function mib_property_carousel($atts)
-    {
-        list($datas, $total) = $this->getDatas(false, 0, 12);
-        $html = $this->getCarouselHtml($datas);
         return $html;
     }
 


### PR DESCRIPTION
## Summary
- Add carousel_display checkbox option for custom shortcodes
- Render dynamic shortcodes as Swiper carousel when carousel_display is enabled
- Remove standalone mib_property_carousel shortcode

## Testing
- `php -l inc/Base/MibCreateShortCode.php`
- `php -l inc/Api/Callbacks/MibManagerCallbacks.php`


------
https://chatgpt.com/codex/tasks/task_e_68c41a5abf308325966e5944da8e6870