### PR TITLE
Add carousel display option for dynamic shortcodes

### DIFF
--- a/inc/Api/Callbacks/MibManagerCallbacks.php
+++ b/inc/Api/Callbacks/MibManagerCallbacks.php
@@ -456,9 +456,10 @@ class MibManagerCallbacks extends MibBaseController
                         'dark_logo' => 'Sötét logó',
                         'display_address' => 'Helység megjelenítés',
                         'garden_connection_filter' => 'Kertkapcsolat szűrés',
-                                        'staircase_filter' => 'Lépcsőház szűrés',
-                                        'sort_filter' => 'Rendezés',
+                        'staircase_filter' => 'Lépcsőház szűrés',
+                        'sort_filter' => 'Rendezés',
                         'gallery_first_image' => 'Lakás galéria első képének megjelenítése',
+                        'carousel_display' => 'Carousel megjelenítés',
                     ];
 	            echo "<hr><strong>További beállítások:</strong><br>";
 	            foreach ($extra_options as $key => $label) {

--- a/inc/Base/MibBaseController.php
+++ b/inc/Base/MibBaseController.php
@@ -1200,21 +1200,82 @@ class MibBaseController
 
         if (!empty($datas)) {
             foreach ($datas as $data) {
+
+                $logo = '';
+                if (isset($this->filterOptionDatas['mib-display_logo']) && $this->filterOptionDatas['mib-display_logo'] == 1 && !empty($data['logo'])) {
+                    $logo = '<img src="'.$data['logo'].'" crossorigin="anonymous">';
+                } elseif (isset($this->selectedShortcodeOption['extras']) && in_array('display_logo', $this->selectedShortcodeOption['extras']) && !empty($data['logo'])) {
+                    $logo = '<img src="'.$data['logo'].'" crossorigin="anonymous">';
+                }
+
+                $address = '';
+                if (isset($this->filterOptionDatas['mib-display_address']) && $this->filterOptionDatas['mib-display_address'] == 1) {
+                    $address = $data['address'];
+                } elseif (isset($this->selectedShortcodeOption['extras']) && in_array('display_address', $this->selectedShortcodeOption['extras'])) {
+                    $address = $data['address'];
+                }
+
                 $html .= '<div class="swiper-slide">';
-                $html .= '<div class="card h-100">';
+                $html .= '<div class="card-wrapper col-md-4 mb-3" data-id="' . esc_attr($data['id']) . '" data-otthon-start="' . ($data['otthonStart'] ? 1 : 0) . '">';
+                $html .= '<div class="card h-100 position-relative">';
+
                 $html .= '<div class="primary-color card-image-wrapper">';
                 $html .= '<img src="' . $data['image'] . '" class="card-img-top" alt="Lakás képe" crossorigin="anonymous">';
+                if (!empty($data['otthonStartBadge'])) {
+                    $html .= '<img id="osiamge" src="' . esc_url($data['otthonStartBadge']) . '" alt="Otthon Start" />';
+                }
                 $html .= '</div>';
-                $html .= '<div class="card-body d-flex flex-column">';
-                $html .= '<h5 class="card-title">' . esc_html($data['rawname']) . '</h5>';
-                $html .= '<p class="card-text mb-4">' . esc_html($data['price']) . '</p>';
-                $html .= '<a href="' . $data['url'] . '" class="mt-auto btn btn-primary">' . __('Megnézem', 'mib') . '</a>';
+
+                $html .= '<div id="apartment-card-body" class="secondary-color card-body d-flex flex-column justify-content-between text-white">';
+
+                $html .= '<div class="mb-3">';
+                $html .= '<div class="d-flex justify-content-between">';
+                if (!empty($logo)) {
+                    $html .= '<div><div class="park-logo">'.$logo.'</div><strong>'.$address.'</strong></div>';
+                }
+                $html .= '<div>';
+                $html .= '<small class="third-text-color '.$data['statusclass'].' d-block">'.$data['statusrow'].'</small>';
+                $html .= '<strong class="fs-5">' . esc_html($data['rawname']) . '</strong>';
+                $html .= '</div>';
+                $html .= '</div>';
+                $html .= '<hr>';
+                $html .= '</div>';
+
+                $html .= '<div class="mb-3">';
+                $html .= '<div class="d-flex justify-content-between">';
+                $html .= '<div><small class="d-block text-muted">Szobák</small><strong class="fs-5">' . esc_html($data['numberOfRooms']) . '</strong></div>';
+                $html .= '<div><small class="d-block text-muted">Méret (m2)</small><strong class="fs-5">' . esc_html($data['salesFloorArea']) . '</strong></div>';
+                $html .= '<div class="text-end"><small class="d-block text-muted">Emelet</small><strong class="fs-5">' . esc_html($data['floor']) . '</strong></div>';
+                $html .= '</div>';
+                $html .= '<hr>';
+                $html .= '</div>';
+
+                $html .= '<div class="list-view-price-container mt-2 mt-md-0">';
+                $html .= '<strong class="fs-4 text-success third-text-color">' . esc_html($data['price']) . '</strong>';
+                $html .= '</div>';
+
+                $html .= '<div class="card-divider list-view-only"></div>';
+
+                $html .= '<div class="list-view-button-wrapper d-flex align-items-center button-row">';
+                if ($data['statusrow'] == 'Elérhető') {
+                    $html .= '<i class="fa fa-regular fa-heart favorite-icon" aria-hidden="true" data-id="' . esc_attr($data['id']) . '"></i>';
+                    $html .= '<a id="cardhref" href="' . $data['url'] . '" class="flex-grow-1">';
+                    $html .= '<button class="primary-color btn btn-light w-100 d-flex align-items-center justify-content-center gap-2 rounded-pill">';
+                    $html .= 'Tudj meg többet <i class="fa fa-arrow-right" aria-hidden="true"></i>';
+                    $html .= '</button>';
+                    $html .= '</a>';
+                } else {
+                    $html .= '<div style="margin-bottom: 80px;"></div>';
+                }
+                $html .= '</div>';
+
+                $html .= '</div>';
                 $html .= '</div>';
                 $html .= '</div>';
                 $html .= '</div>';
             }
         } else {
-            $html .= '<div class="swiper-slide"><p>' . __('Nem található ingatlan', 'mib') . '</p></div>';
+            $html .= '<div class="swiper-slide"><p><b> Nem található ingatlan </b></p></div>';
         }
 
         $html .= '</div>';

--- a/inc/Base/MibCreateShortCode.php
+++ b/inc/Base/MibCreateShortCode.php
@@ -17,7 +17,6 @@ class MibCreateShortCode extends MibBaseController
         add_shortcode('mib_list_apartman_catalog_filters', array($this, 'mib_list_apartman_catalog_filters'));
         add_shortcode('mib_residential_documents', array($this, 'mib_residential_documents'));
         add_shortcode('mib_residential_gallery', array($this, 'mib_residential_gallery'));
-        add_shortcode('mib_property_carousel', array($this, 'mib_property_carousel'));
 
 
         add_action('init', array($this, 'custom_property_rewrite_rule'));
@@ -146,7 +145,11 @@ class MibCreateShortCode extends MibBaseController
 
                 list($datas, $total) = $this->getDatas(false, 0, $config['number_of_apartment']);
 
-                $html = $this->getCardHtmlShortCode($datas, $total, 1, $config, $shortcode_name, $this->numberOfApartmens);
+                if (!empty($config['extras']) && in_array('carousel_display', $config['extras'])) {
+                    $html = $this->getCarouselHtml($datas);
+                } else {
+                    $html = $this->getCardHtmlShortCode($datas, $total, 1, $config, $shortcode_name, $this->numberOfApartmens);
+                }
 
                 return $html;
 
@@ -242,13 +245,6 @@ class MibCreateShortCode extends MibBaseController
     {
         list($datas, $total) = $this->getDatas(false, 0, 9);
         $html = $this->getCardHtml($datas, $total, 1, []);
-        return $html;
-    }
-
-    public function mib_property_carousel($atts)
-    {
-        list($datas, $total) = $this->getDatas(false, 0, 12);
-        $html = $this->getCarouselHtml($datas);
         return $html;
     }
 


### PR DESCRIPTION
## Summary
- Add carousel_display checkbox option for custom shortcodes
- Render dynamic shortcodes as Swiper carousel when carousel_display is enabled
- Remove standalone mib_property_carousel shortcode
- Render carousel items with full card layout identical to standard view

## Testing
- `php -l inc/Base/MibBaseController.php`
- `php -l inc/Base/MibCreateShortCode.php`
- `php -l inc/Api/Callbacks/MibManagerCallbacks.php`


------
https://chatgpt.com/codex/tasks/task_e_68c41a5abf308325966e5944da8e6870