### PR TITLE
Enable carousel to load additional properties dynamically

### DIFF
--- a/assets/mib-carousel.js
+++ b/assets/mib-carousel.js
@@ -1,8 +1,8 @@
-// Initialize Swiper carousel for property shortcode
+// Initialize Swiper carousel for property shortcode and load more items on demand
 document.addEventListener('DOMContentLoaded', function () {
     var carousels = document.querySelectorAll('.mib-property-carousel');
     carousels.forEach(function (carousel) {
-        new Swiper(carousel, {
+        var swiper = new Swiper(carousel, {
             slidesPerView: 1,
             slidesPerGroup: 1, // mobilon 1-et lapoz
             spaceBetween: 20,
@@ -21,5 +21,44 @@ document.addEventListener('DOMContentLoaded', function () {
                 }
             }
         });
+
+        var shortcode = carousel.dataset.shortcode;
+        var perPage = carousel.dataset.apartman_number;
+        if (shortcode) {
+            carousel.dataset.page = carousel.dataset.page || '1';
+            swiper.on('reachEnd', function () {
+                if (carousel.dataset.loading === '1' || carousel.dataset.finished === '1') return;
+
+                var nextPage = parseInt(carousel.dataset.page, 10) + 1;
+                carousel.dataset.loading = '1';
+
+                fetch(ajaxurl, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' },
+                    body: new URLSearchParams({
+                        action: 'load_more_items',
+                        page: nextPage,
+                        shortcode: shortcode,
+                        apartman_number: perPage,
+                        page_type: 'carousel'
+                    })
+                })
+                    .then(function (response) { return response.json(); })
+                    .then(function (data) {
+                        carousel.dataset.loading = '0';
+                        if (data.success && data.data && data.data.count > 0) {
+                            var wrapper = carousel.querySelector('.swiper-wrapper');
+                            wrapper.insertAdjacentHTML('beforeend', data.data.html);
+                            carousel.dataset.page = nextPage;
+                            swiper.update();
+                        } else {
+                            carousel.dataset.finished = '1';
+                        }
+                    })
+                    .catch(function () {
+                        carousel.dataset.loading = '0';
+                    });
+            });
+        }
     });
 });

--- a/inc/Base/MibBaseController.php
+++ b/inc/Base/MibBaseController.php
@@ -1193,9 +1193,9 @@ class MibBaseController
         return $html;
     }
 
-    public function getCarouselHtml($datas)
+    public function getCarouselHtml($datas, $shortcodeName = '', $apartman_number = 12)
     {
-        $html = '<div class="mib-property-carousel swiper">';
+        $html = '<div class="mib-property-carousel swiper" data-shortcode="' . esc_attr($shortcodeName) . '" data-apartman_number="' . esc_attr($apartman_number) . '" data-page="1">';
         $html .= '<div class="swiper-wrapper">';
 
         if (!empty($datas)) {
@@ -1283,6 +1283,90 @@ class MibBaseController
         $html .= '<div class="swiper-button-next"></div>';
         $html .= '<div class="swiper-pagination"></div>';
         $html .= '</div>';
+
+        return $html;
+    }
+
+    public function getCarouselSlidesHtml($datas)
+    {
+        $html = '';
+
+        if (!empty($datas)) {
+            foreach ($datas as $data) {
+                $logo = '';
+                if (isset($this->filterOptionDatas['mib-display_logo']) && $this->filterOptionDatas['mib-display_logo'] == 1 && !empty($data['logo'])) {
+                    $logo = '<img src="'.$data['logo'].'" crossorigin="anonymous">';
+                } elseif (isset($this->selectedShortcodeOption['extras']) && in_array('display_logo', $this->selectedShortcodeOption['extras']) && !empty($data['logo'])) {
+                    $logo = '<img src="'.$data['logo'].'" crossorigin="anonymous">';
+                }
+
+                $address = '';
+                if (isset($this->filterOptionDatas['mib-display_address']) && $this->filterOptionDatas['mib-display_address'] == 1) {
+                    $address = $data['address'];
+                } elseif (isset($this->selectedShortcodeOption['extras']) && in_array('display_address', $this->selectedShortcodeOption['extras'])) {
+                    $address = $data['address'];
+                }
+
+                $html .= '<div class="swiper-slide">';
+                $html .= '<div class="card-wrapper" data-id="' . esc_attr($data['id']) . '" data-otthon-start="' . ($data['otthonStart'] ? 1 : 0) . '">';
+                $html .= '<div class="card h-100 position-relative">';
+
+                $html .= '<div class="primary-color card-image-wrapper">';
+                $html .= '<img src="' . $data['image'] . '" class="card-img-top" alt="Lakás képe" crossorigin="anonymous">';
+                if (!empty($data['otthonStartBadge'])) {
+                    $html .= '<img id="osiamge" src="' . esc_url($data['otthonStartBadge']) . '" alt="Otthon Start" />';
+                }
+                $html .= '</div>';
+
+                $html .= '<div id="apartment-card-body" class="secondary-color card-body d-flex flex-column justify-content-between text-white">';
+
+                $html .= '<div class="mb-3">';
+                $html .= '<div class="d-flex justify-content-between">';
+                if (!empty($logo)) {
+                    $html .= '<div><div class="park-logo">'.$logo.'</div><strong>'.$address.'</strong></div>';
+                }
+                $html .= '<div>';
+                $html .= '<small class="third-text-color '.$data['statusclass'].' d-block">'.$data['statusrow'].'</small>';
+                $html .= '<strong class="fs-5">' . esc_html($data['rawname']) . '</strong>';
+                $html .= '</div>';
+                $html .= '</div>';
+                $html .= '<hr>';
+                $html .= '</div>';
+
+                $html .= '<div class="mb-3">';
+                $html .= '<div class="d-flex justify-content-between">';
+                $html .= '<div><small class="d-block text-muted">Szobák</small><strong class="fs-5">' . esc_html($data['numberOfRooms']) . '</strong></div>';
+                $html .= '<div><small class="d-block text-muted">Méret (m2)</small><strong class="fs-5">' . esc_html($data['salesFloorArea']) . '</strong></div>';
+                $html .= '<div class="text-end"><small class="d-block text-muted">Emelet</small><strong class="fs-5">' . esc_html($data['floor']) . '</strong></div>';
+                $html .= '</div>';
+                $html .= '<hr>';
+                $html .= '</div>';
+
+                $html .= '<div class="list-view-price-container mt-2 mt-md-0">';
+                $html .= '<strong class="fs-4 text-success third-text-color">' . esc_html($data['price']) . '</strong>';
+                $html .= '</div>';
+
+                $html .= '<div class="card-divider list-view-only"></div>';
+
+                $html .= '<div class="list-view-button-wrapper d-flex align-items-center button-row">';
+                if ($data['statusrow'] == 'Elérhető') {
+                    $html .= '<i class="fa fa-regular fa-heart favorite-icon" aria-hidden="true" data-id="' . esc_attr($data['id']) . '"></i>';
+                    $html .= '<a id="cardhref" href="' . $data['url'] . '" class="flex-grow-1">';
+                    $html .= '<button class="primary-color btn btn-light w-100 d-flex align-items-center justify-content-center gap-2 rounded-pill">';
+                    $html .= 'Tudj meg többet <i class="fa fa-arrow-right" aria-hidden="true"></i>';
+                    $html .= '</button>';
+                    $html .= '</a>';
+                } else {
+                    $html .= '<div style="margin-bottom: 80px;"></div>';
+                }
+                $html .= '</div>';
+
+                $html .= '</div>';
+                $html .= '</div>';
+                $html .= '</div>';
+                $html .= '</div>';
+            }
+        }
 
         return $html;
     }

--- a/inc/Base/MibCreateShortCode.php
+++ b/inc/Base/MibCreateShortCode.php
@@ -146,7 +146,7 @@ class MibCreateShortCode extends MibBaseController
                 list($datas, $total) = $this->getDatas(false, 0, $config['number_of_apartment']);
 
                 if (!empty($config['extras']) && in_array('carousel_display', $config['extras'])) {
-                    $html = $this->getCarouselHtml($datas);
+                    $html = $this->getCarouselHtml($datas, $shortcode_name, $config['number_of_apartment']);
                 } else {
                     $html = $this->getCardHtmlShortCode($datas, $total, 1, $config, $shortcode_name, $this->numberOfApartmens);
                 }

--- a/inc/Base/MibEnqueue.php
+++ b/inc/Base/MibEnqueue.php
@@ -1048,8 +1048,12 @@ class MibEnqueue extends MibBaseController
 		$mib = new MibAuthController();
 		$datas = $mib->getApartmentsForFrontEnd($perPage, $_POST['page'], $args);
 
-		$table_data = $this->setDataToTable($datas);
-		$html = $this->getMoreCards($table_data, $datas['total'], $_POST['page']);
+                $table_data = $this->setDataToTable($datas);
+                if (isset($_POST['page_type']) && $_POST['page_type'] === 'carousel') {
+                    $html = $this->getCarouselSlidesHtml($table_data);
+                } else {
+                    $html = $this->getMoreCards($table_data, $datas['total'], $_POST['page']);
+                }
 
 		wp_send_json_success([
 			'html' 		 => $html,
@@ -1060,12 +1064,11 @@ class MibEnqueue extends MibBaseController
 	        'price_slider_max' => $price_slider_max,
 	        'floor_slider_min' => $floor_slider_min,
 	        'floor_slider_max' => $floor_slider_max,
-	        'room_slider_min' => $room_slider_min,
-        	'room_slider_max' => $room_slider_max,
-        	'garden_connection' => $garden_connection,
-	        'orientation_filter' => ( (isset($_POST['apartman_number']) && !empty($this->filterType) && in_array('orientation_filters', $this->filterType['extras'])) ) ? 1 : null,
-	        'available_only' => ( (isset($_POST['apartman_number']) && !empty($this->filterType) && in_array('available_only', $this->filterType['extras'])) ) ? 1 : null
-	    ]);
+                'room_slider_min' => $room_slider_min,
+                'room_slider_max' => $room_slider_max,
+                'orientation_filter' => ( (isset($_POST['apartman_number']) && !empty($this->filterType) && in_array('orientation_filters', $this->filterType['extras'])) ) ? 1 : null,
+                'available_only' => ( (isset($_POST['apartman_number']) && !empty($this->filterType) && in_array('available_only', $this->filterType['extras'])) ) ? 1 : null
+            ]);
 
 	    wp_die();
 		


### PR DESCRIPTION
## Summary
- Add Swiper `reachEnd` handler to fetch more properties via AJAX in carousel mode
- Pass shortcode context in carousel markup and provide PHP endpoint to return slide HTML
- Support carousel pagination on the server and remove undefined variable in AJAX response

## Testing
- `php -l inc/Base/MibBaseController.php`
- `php -l inc/Base/MibCreateShortCode.php`
- `php -l inc/Base/MibEnqueue.php`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7cedda03c8325988dd37c92d11d12