### PR TITLE
Move carousel navigation outside container

### DIFF
--- a/assets/mib-frontend.css
+++ b/assets/mib-frontend.css
@@ -1500,30 +1500,37 @@ width: 100% !important; /* Kis százalékos szélesség, hogy négy blokk elfér
     padding: 0;
 }
 
+
 .mib-property-carousel {
   position: relative;
+  margin-bottom: 40px;
+}
+
+.mib-property-carousel.swiper {
+  overflow: visible;
 }
 
 .mib-property-carousel .swiper-button-prev,
 .mib-property-carousel .swiper-button-next {
+  position: absolute;
   top: 50%;
   transform: translateY(-50%);
   width: 40px;   /* opcionális */
   height: 40px;  /* opcionális */
+  z-index: 10;
 }
 
 .mib-property-carousel .swiper-button-prev {
-  position: fixed;
-  top: 450px;
-  left: 590px;
+  left: -50px;
 }
 
 .mib-property-carousel .swiper-button-next {
-    position: fixed;
-    top: 450px;
-    right: 611px;
+    right: -50px;
 }
+
 .mib-property-carousel .swiper-pagination-bullets{
-    position: fixed;
-    top: 800px;
+    position: absolute;
+    bottom: -30px;
+    left: 50%;
+    transform: translateX(-50%);
 }


### PR DESCRIPTION
## Summary
- reposition carousel arrows outside slider container
- place pagination bullets below carousel
- keep arrows and bullets visible by allowing overflow and raising z-index

## Testing
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68c80ce0fc508325b18a58407131da0b