### PR TITLE
Add supported price option to dynamic shortcodes

### DIFF
--- a/assets/mib-frontend.css
+++ b/assets/mib-frontend.css
@@ -1100,6 +1100,23 @@ width: 100% !important; /* Kis százalékos szélesség, hogy négy blokk elfér
     text-align: center;
 }
 
+.mib-supported-price {
+    margin-top: 4px;
+    font-size: 0.95rem;
+    text-align: center;
+    color: #ffffff;
+}
+
+.mib-supported-price .mib-supported-price-label {
+    font-weight: 500;
+    margin-right: 4px;
+}
+
+.mib-supported-price .mib-supported-price-value {
+    font-weight: 600;
+    color: #3ecf8e;
+}
+
 .card.list-view .list-view-price-container {
     position: absolute;
     bottom: 0.6rem;

--- a/inc/Api/Callbacks/MibManagerCallbacks.php
+++ b/inc/Api/Callbacks/MibManagerCallbacks.php
@@ -455,6 +455,7 @@ class MibManagerCallbacks extends MibBaseController
                         'display_logo' => 'Logo megjelenítés',
                         'dark_logo' => 'Sötét logó',
                         'display_address' => 'Helység megjelenítés',
+                        'display_supported_price' => 'Támogatással elérhető ár megjelenítése',
                         'garden_connection_filter' => 'Kertkapcsolat szűrés',
                         'staircase_filter' => 'Lépcsőház szűrés',
                         'sort_filter' => 'Rendezés',

--- a/inc/Base/MibBaseController.php
+++ b/inc/Base/MibBaseController.php
@@ -266,16 +266,25 @@ class MibBaseController
 			    }
 			}
 
-		    $table_data[] = array(
-		        'id' => $item->id,
-		        'rawname' => $item->name,
-		        'name' => ($item->status == 'Sold') 
-				    ? '<a id="mibhre">' . esc_html($item->name) . '</a>' 
-				    : '<a id="mibhre" href="' . home_url('/lakas/' . $projectSlug . '/' . sanitize_title($item->name) . '/') . '">' . $item->name . '</a>',
-				'url' => home_url('/lakas/' . $projectSlug . '/' . sanitize_title($item->name) . '/'),
-		        'numberOfRooms' => $item->numberOfRooms,
-		        'price' => ($item->status == 'Available' || $item->status == 'Reserved') ? (!is_null($item->price) ? number_format($item->price, 0) . ' Ft' : '') : '',
-		        'salesFloorArea' => $item->salesFloorArea . ' m²',
+                    $priceDisplay = '';
+                    $supportedPriceDisplay = '';
+
+                    if (($item->status == 'Available' || $item->status == 'Reserved') && !is_null($item->price)) {
+                        $priceDisplay = number_format($item->price, 0) . ' Ft';
+                        $supportedPriceDisplay = number_format($item->price / 1.05, 0) . ' Ft';
+                    }
+
+                    $table_data[] = array(
+                        'id' => $item->id,
+                        'rawname' => $item->name,
+                        'name' => ($item->status == 'Sold')
+                                    ? '<a id="mibhre">' . esc_html($item->name) . '</a>'
+                                    : '<a id="mibhre" href="' . home_url('/lakas/' . $projectSlug . '/' . sanitize_title($item->name) . '/') . '">' . $item->name . '</a>',
+                                'url' => home_url('/lakas/' . $projectSlug . '/' . sanitize_title($item->name) . '/'),
+                        'numberOfRooms' => $item->numberOfRooms,
+                        'price' => $priceDisplay,
+                        'supportedPrice' => $supportedPriceDisplay,
+                        'salesFloorArea' => $item->salesFloorArea . ' m²',
 		        'floor' => ($item->floor == 0) ? 'földszint' : $item->floor,
 		        'balcony' => $item->balconyFloorArea . ' m²',
 		        'orientation' => array_search($item->orientation, $this->orientation), // Tájolás formázása
@@ -850,12 +859,19 @@ class MibBaseController
 				    $html .= '</div>';
 
 					// Ár
-					$html .= '<div class="list-view-price-container mt-2 mt-md-0" style="display: flex; align-items: center; gap: 10px;">';
-						$html .= '<strong class="fs-4 text-success third-text-color">' . esc_html($data['price']) . '</strong>';
-					$html .= '</div>';
+                                        $html .= '<div class="list-view-price-container mt-2 mt-md-0" style="display: flex; align-items: center; gap: 10px;">';
+                                                $html .= '<strong class="fs-4 text-success third-text-color">' . esc_html($data['price']) . '</strong>';
+                                        $html .= '</div>';
 
-					// Függőleges elválasztó (gomb elé, csak lista nézetben)
-					$html .= '<div class="card-divider list-view-only"></div>';
+                                        if (!empty($filterType['extras']) && in_array('display_supported_price', $filterType['extras']) && !empty($data['supportedPrice'])) {
+                                            $html .= '<div class="mib-supported-price">';
+                                            $html .= '<span class="mib-supported-price-label">' . esc_html__('Támogatással elérhető ár:', 'mib') . '</span>';
+                                            $html .= '<span class="mib-supported-price-value">' . esc_html($data['supportedPrice']) . '</span>';
+                                            $html .= '</div>';
+                                        }
+
+                                        // Függőleges elválasztó (gomb elé, csak lista nézetben)
+                                        $html .= '<div class="card-divider list-view-only"></div>';
 
 					// Gomb
 					if ($data['statusrow'] == 'Elérhető') {
@@ -1266,11 +1282,18 @@ class MibBaseController
 	            $html .= '              </div>';
 
 	            // Ár
-	            $html .= '              <div class="list-view-price-container mt-2 mt-md-0">';
-	            $html .= '                <strong class="fs-4 text-success third-text-color">' . esc_html($data['price']) . '</strong>';
-	            $html .= '              </div>';
+                    $html .= '              <div class="list-view-price-container mt-2 mt-md-0">';
+                    $html .= '                <strong class="fs-4 text-success third-text-color">' . esc_html($data['price']) . '</strong>';
+                    $html .= '              </div>';
 
-	            $html .= '              <div class="card-divider list-view-only"></div>';
+                    if (!empty($this->selectedShortcodeOption['extras']) && in_array('display_supported_price', $this->selectedShortcodeOption['extras']) && !empty($data['supportedPrice'])) {
+                        $html .= '              <div class="mib-supported-price">';
+                        $html .= '                <span class="mib-supported-price-label">' . esc_html__('Támogatással elérhető ár:', 'mib') . '</span>';
+                        $html .= '                <span class="mib-supported-price-value">' . esc_html($data['supportedPrice']) . '</span>';
+                        $html .= '              </div>';
+                    }
+
+                    $html .= '              <div class="card-divider list-view-only"></div>';
 
 	            // Gomb sor
 	            $html .= '              <div class="list-view-button-wrapper d-flex align-items-center button-row">';
@@ -1367,6 +1390,13 @@ class MibBaseController
                 $html .= '<div class="list-view-price-container mt-2 mt-md-0">';
                 $html .= '<strong class="fs-4 text-success third-text-color">' . esc_html($data['price']) . '</strong>';
                 $html .= '</div>';
+
+                if (!empty($this->selectedShortcodeOption['extras']) && in_array('display_supported_price', $this->selectedShortcodeOption['extras']) && !empty($data['supportedPrice'])) {
+                    $html .= '<div class="mib-supported-price">';
+                    $html .= '<span class="mib-supported-price-label">' . esc_html__('Támogatással elérhető ár:', 'mib') . '</span>';
+                    $html .= '<span class="mib-supported-price-value">' . esc_html($data['supportedPrice']) . '</span>';
+                    $html .= '</div>';
+                }
 
                 $html .= '<div class="card-divider list-view-only"></div>';
 


### PR DESCRIPTION
## Summary
- calculate and store the 5% reduced supported price alongside shortcode apartment data
- add an admin extra option to toggle whether the supported price is rendered for a shortcode
- render the optional supported price beneath prices in card and carousel layouts with dedicated styling

## Testing
- php -l inc/Base/MibBaseController.php
- php -l inc/Api/Callbacks/MibManagerCallbacks.php

------
https://chatgpt.com/codex/tasks/task_e_68c9174c80908325b0fa856c549290b3