### PR TITLE
Fix cross-sell recommendation loading

### DIFF
--- a/inc/Base/MibBaseController.php
+++ b/inc/Base/MibBaseController.php
@@ -155,6 +155,7 @@ class MibBaseController
         $this->pluginUrl = plugin_dir_url(dirname(__FILE__, 2));
         $this->pluginName = plugin_basename(dirname(__FILE__, 3)) . "/mib.php";
         $this->filterOptionDatas = maybe_unserialize(get_option('mib_filter_options'));
+        $this->filterOptionCrossSellDatas = maybe_unserialize(get_option('mib_cross_sell_options'));
 
         // Adminon beállított residentialParkId
         $this->mibOptions = maybe_unserialize(get_option('mib_options'));


### PR DESCRIPTION
## Summary
- load the saved cross-sell option flags when bootstrapping the base controller
- rebuild the recommendation lookup to apply the selected filters within the same residential park and type
- pull assets from each recommended apartment so the rendered cards show the correct data

## Testing
- php -l inc/Base/MibCreateShortCode.php
- php -l inc/Base/MibBaseController.php

------
https://chatgpt.com/codex/tasks/task_e_68c93466b2c0832588e12947f41cbc2c