### PR TITLE
Enable infinite scroll for dynamic shortcode listings

### DIFF
--- a/assets/mib-frontend.css
+++ b/assets/mib-frontend.css
@@ -1517,6 +1517,11 @@ width: 100% !important; /* Kis százalékos szélesség, hogy négy blokk elfér
     padding: 0;
 }
 
+.mib-infinite-scroll-sentinel {
+    width: 100%;
+    height: 1px;
+}
+
 
 /* Bal/jobb kilógás asztalin */
 .mib-carousel-outer .swiper-button-prev { left: -50px; }

--- a/inc/Api/Callbacks/MibManagerCallbacks.php
+++ b/inc/Api/Callbacks/MibManagerCallbacks.php
@@ -443,11 +443,12 @@ class MibManagerCallbacks extends MibBaseController
 	            }
 
 	            // Extra opciók
-	            $extra_options = [
-	            	'favorites_filter' => 'Kedvencek szűrése',
-	                'reset_filters' => 'Szűrők törlése',
-	                'use_number_inputs' => 'Slider helyett szám inputok',
-	                'load_more' => 'Paginate helyett Load more',
+                    $extra_options = [
+                        'favorites_filter' => 'Kedvencek szűrése',
+                        'reset_filters' => 'Szűrők törlése',
+                        'use_number_inputs' => 'Slider helyett szám inputok',
+                        'load_more' => 'Paginate helyett Load more',
+                        'infinite_scroll' => 'Végtelen görgetés',
 	                'available_only' => 'Elérhetőség',
                         'hide_unavailable' => 'Nem elérhetők elrejtése alapbeállítás',
                         'orientation_filters' => 'Tájolás szűrés',


### PR DESCRIPTION
## Summary
- add an infinite scroll checkbox to shortcode extra options
- hide the load more button and emit sentinel markup when infinite scroll is enabled while exposing new pagination metadata
- update the front-end load more handler to auto-fetch pages via IntersectionObserver and style the sentinel element

## Testing
- php -l inc/Api/Callbacks/MibManagerCallbacks.php
- php -l inc/Base/MibBaseController.php
- php -l inc/Base/MibEnqueue.php

------
https://chatgpt.com/codex/tasks/task_e_68c9584971308325bfc6b12079b4d223