### PR TITLE
Add discount price display for apartments

### DIFF
--- a/assets/mib-frontend.css
+++ b/assets/mib-frontend.css
@@ -1100,6 +1100,37 @@ width: 100% !important; /* Kis százalékos szélesség, hogy négy blokk elfér
     text-align: center;
 }
 
+.mib-old-price {
+    font-size: 0.85rem;
+    text-decoration: line-through;
+    color: #b5b5b5;
+}
+
+.mib-new-price {
+    font-weight: 700;
+}
+
+.list-view-price-container .mib-old-price,
+.apartment-price .mib-old-price {
+    display: block;
+    margin-bottom: 4px;
+}
+
+.list-view-price-container .mib-new-price,
+.apartment-price .mib-new-price {
+    display: block;
+}
+
+.recommended-price .mib-old-price,
+.recommended-price .mib-new-price {
+    display: inline-block;
+}
+
+.recommended-price .mib-old-price {
+    margin-right: 0.5rem;
+    color: #6c757d;
+}
+
 .mib-supported-price {
     margin-top: 4px;
     font-size: 0.95rem;


### PR DESCRIPTION
## Summary
- capture discount price information when building apartment data and reuse raw values for formatting
- render strikethrough original prices alongside highlighted discounted prices on cards, carousels, and the recommended list
- show the dual price styling on the apartment detail page and add CSS helpers for the old/new price styling

## Testing
- php -l inc/Base/MibBaseController.php

------
https://chatgpt.com/codex/tasks/task_e_68ca706d0bd88325862883425c5bfeea