### PR TITLE
Handle park ID parsing and AJAX script localization

### DIFF
--- a/inc/Api/MibSettingsApi.php
+++ b/inc/Api/MibSettingsApi.php
@@ -42,18 +42,18 @@ class MibSettingsApi
 		return $this;
 	}
 
-	public function setSubPagesTitle(string $title = ''){
+        public function setSubPagesTitle(?string $title = null){
 
-		if (empty($this->adminPages)) {
+                if (empty($this->adminPages)) {
 
-		}else{
+                }else{
 
-		}
+                }
 
-		return $this; 
-		
+                return $this;
 
-	}
+
+        }
 	public function addSubPages(array $pages){
 
 		$this->adminSubPages = $pages;

--- a/inc/Base/MibEnqueue.php
+++ b/inc/Base/MibEnqueue.php
@@ -160,7 +160,11 @@ class MibEnqueue extends MibBaseController
         wp_enqueue_script('nouislider-js', 'https://cdn.jsdelivr.net/npm/nouislider@15.7.0/dist/nouislider.min.js', array(), null, true);
         wp_enqueue_style('nouislider-css', 'https://cdn.jsdelivr.net/npm/nouislider@15.7.0/dist/nouislider.min.css');
         wp_enqueue_script('mib-frontend-script', plugin_dir_url(dirname(__FILE__, 3)).'mib/assets/mib-frontend.js', array('jquery', 'nouislider-js'), null, true);
-            wp_localize_script('mib-frontend-script', 'ajaxurl', admin_url('admin-ajax.php'));
+        wp_add_inline_script(
+            'mib-frontend-script',
+            'var ajaxurl = ' . wp_json_encode(admin_url('admin-ajax.php')) . ';',
+            'before'
+        );
 
         // Swiper carousel for property shortcode
         wp_enqueue_style('swiper-css', 'https://cdn.jsdelivr.net/npm/swiper@10/swiper-bundle.min.css');


### PR DESCRIPTION
## Summary
- add a dedicated `parseParkIds` helper to normalise park identifiers from various sources before filtering
- replace the deprecated `wp_localize_script` usage with an inline definition of the global `ajaxurl`
- mark the optional settings title argument as explicitly nullable to avoid PHP 8.4 notices

## Testing
- php -l inc/Base/MibBaseController.php
- php -l inc/Base/MibEnqueue.php
- php -l inc/Api/MibSettingsApi.php

------
https://chatgpt.com/codex/tasks/task_e_68ca9afb64448325822a9bc41e6c6ec8