### PR TITLE
Make Otthon Start badge toggle Otthon Start filter

### DIFF
--- a/assets/mib-frontend.css
+++ b/assets/mib-frontend.css
@@ -1555,11 +1555,12 @@ width: 100% !important; /* Kis százalékos szélesség, hogy négy blokk elfér
 .mib-gallery-next {
     right: 20px;
 }
-#osiamge{
+.mib-otthonstart-badge {
     position:absolute;
     top:10px;
     right:10px;
     width:60px;
+    cursor: pointer;
 }
 
 #saleimagebadge{

--- a/assets/mib-frontend.js
+++ b/assets/mib-frontend.js
@@ -4457,6 +4457,32 @@ jQuery(document).ready(function($) {
         }
     });
 
+    function triggerOtthonStartFilter() {
+        const $checkbox = $('.catalog-otthonstart-checkbox');
+
+        if (!$checkbox.length) {
+            return;
+        }
+
+        if (!$checkbox.is(':checked')) {
+            $checkbox.prop('checked', true);
+        }
+
+        $checkbox.trigger('change');
+    }
+
+    $(document).on('click', '.mib-otthonstart-badge', function (e) {
+        e.preventDefault();
+        triggerOtthonStartFilter();
+    });
+
+    $(document).on('keydown', '.mib-otthonstart-badge', function (e) {
+        if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            triggerOtthonStartFilter();
+        }
+    });
+
     // Otthon start filter
     $(document).on('change', '.catalog-otthonstart-checkbox', function (e) {
 

--- a/inc/Base/MibBaseController.php
+++ b/inc/Base/MibBaseController.php
@@ -508,7 +508,7 @@ class MibBaseController
                     $html .= '<div class="apartment-plan position-relative">';
                     $html .= '<img crossorigin="anonymous" src="' . esc_url($data['gallery_first']) . '" alt="Lakás Kép">';
                     if (!empty($data['otthonStartBadge'])) {
-                        $html .= '<img id="osiamge" src="' . esc_url($data['otthonStartBadge']) . '" alt="Otthon Start"/>';
+                        $html .= '<img class="mib-otthonstart-badge" src="' . esc_url($data['otthonStartBadge']) . '" alt="Otthon Start" role="button" tabindex="0" />';
                     }
                     $html .= '</div>';
 
@@ -991,7 +991,7 @@ class MibBaseController
                 $html .= '<div class="primary-color card-image-wrapper">';
                 $html .= '<img src="' . ((!empty($data['szintrajz_img'])) ? $data['szintrajz_img'] : $data['image']) . '" class="card-img-top" alt="Lakás képe" crossorigin="anonymous">';
                 if (!empty($data['otthonStartBadge'])) {
-                    $html .= '<img id="osiamge" src="' . esc_url($data['otthonStartBadge']) . '" alt="Otthon Start" />';
+                    $html .= '<img class="mib-otthonstart-badge" src="' . esc_url($data['otthonStartBadge']) . '" alt="Otthon Start" role="button" tabindex="0" />';
                 }
                 $html .= '</div>';
 
@@ -1180,7 +1180,7 @@ class MibBaseController
                         $html .= '<div class="primary-color card-image-wrapper">';
                         $html .= '<img src="' . $data['image'] . '" class="card-img-top" alt="Lakás képe" crossorigin="anonymous">';
                         if (!empty($data['otthonStartBadge'])) {
-                            $html .= '<img id="osiamge" src="' . esc_url($data['otthonStartBadge']) . '" alt="Otthon Start" />';
+                            $html .= '<img class="mib-otthonstart-badge" src="' . esc_url($data['otthonStartBadge']) . '" alt="Otthon Start" role="button" tabindex="0" />';
                         }
                         $html .= '</div>';
 
@@ -1312,7 +1312,7 @@ class MibBaseController
                         $html .= '<div class="primary-color card-image-wrapper">';
                         $html .= '<img src="' . ((!empty($data['szintrajz_img'])) ? $data['szintrajz_img'] : $data['image']) . '" class="card-img-top" alt="Lakás képe" crossorigin="anonymous">';
                         if (!empty($data['otthonStartBadge'])) {
-                            $html .= '<img id="osiamge" src="' . esc_url($data['otthonStartBadge']) . '" alt="Otthon Start" />';
+                            $html .= '<img class="mib-otthonstart-badge" src="' . esc_url($data['otthonStartBadge']) . '" alt="Otthon Start" role="button" tabindex="0" />';
                         }
                         $html .= '</div>';
 
@@ -1447,9 +1447,9 @@ class MibBaseController
 	            // Kép blokk
 	            $html .= '            <div class="primary-color card-image-wrapper">';
 	            $html .= '              <img src="' . esc_url($data['image']) . '" class="card-img-top" alt="Lakás képe" crossorigin="anonymous">';
-	            if (!empty($data['otthonStartBadge'])) {
-	                $html .= '              <img id="osiamge" src="' . esc_url($data['otthonStartBadge']) . '" alt="Otthon Start">';
-	            }
+               if (!empty($data['otthonStartBadge'])) {
+                   $html .= '              <img class="mib-otthonstart-badge" src="' . esc_url($data['otthonStartBadge']) . '" alt="Otthon Start" role="button" tabindex="0">';
+               }
 	            $html .= '            </div>';
 
 	            // Card body
@@ -1570,7 +1570,7 @@ class MibBaseController
                 $html .= '<div class="primary-color card-image-wrapper">';
                 $html .= '<img src="' . $data['image'] . '" class="card-img-top" alt="Lakás képe" crossorigin="anonymous">';
                 if (!empty($data['otthonStartBadge'])) {
-                    $html .= '<img id="osiamge" src="' . esc_url($data['otthonStartBadge']) . '" alt="Otthon Start" />';
+                    $html .= '<img class="mib-otthonstart-badge" src="' . esc_url($data['otthonStartBadge']) . '" alt="Otthon Start" role="button" tabindex="0" />';
                 }
                 $html .= '</div>';
 


### PR DESCRIPTION
## Summary
- replace the static Otthon Start badge image output with a reusable class and button semantics
- trigger the Otthon Start catalog checkbox whenever the badge is clicked or keyboard activated
- update the badge styling to match the new class and provide a pointer cursor

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6909e6d32a908325abb69d5b0f183884